### PR TITLE
Prevent error when wrong username was provided

### DIFF
--- a/nginx-ldap-auth-daemon
+++ b/nginx-ldap-auth-daemon
@@ -79,6 +79,9 @@ def check_auth(user, passwd, allowusr, allowgr):
             data = ldap_connection.search_s(base=conf['base'], scope=ldap.SCOPE_SUBTREE, filterstr='(&(objectClass=user)(sAMAccountName=' + user + '))')
             if data:
                 data = data[0][1]
+                # check if search found user
+                if 'distinguishedName' not in data:
+                    return False
                 # check password
                 try:
                     ldap_connection.simple_bind_s(data['distinguishedName'][0], passwd)


### PR DESCRIPTION
When a wrong password was provided _check_auth_ returns with false. But when a wrong username was provided there is an unhandled error:
```
...
    ldap_connection.simple_bind_s(data['distinguishedName'][0], passwd)
TypeError: list indices must be integers, not str
```
Because of this the proxy replies with 500 error and nginx doesn't prompt for account details again. This can be prevented by checking that _distinguishedName_ is present in _data_.